### PR TITLE
Fix: Update Bot initialisation with Discord intents permissions

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,12 +5,15 @@ This file is the entryway to the bot. If you want to run the bot, this is the fi
 # Package imports
 import dotenv 
 import os
+import discord
 from discord.ext import commands
 
 dotenv.load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN")
 
-bot = commands.Bot(command_prefix="f")
+intents = discord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="f", intents=intents)
 BOT_ID = 880775837522198528
 
 @bot.event


### PR DESCRIPTION
### Problem

Couldn't run the bot because there was no intents specified.

```sh
> python3 main.py
Traceback (most recent call last):
  File "/Users/clarissat/projects/amg-discord-bot/main.py", line 13, in <module>
    bot = commands.Bot(command_prefix="f")
TypeError: BotBase.__init__() missing 1 required keyword-only argument: 'intents'
```

### Solution

This PR:

- Creates a `discord.Intents` object to allow the bot to assess message contents.
- Passes in intents object to initialise bot.